### PR TITLE
Pin react-router-dom to version 7.7.0

### DIFF
--- a/PocSplitUpload/ClientApp/package.json
+++ b/PocSplitUpload/ClientApp/package.json
@@ -8,7 +8,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-bootstrap": "^0.26.2",
-    "react-router-dom": "^7.0.1",
+    "react-router-dom": "7.7.0",
     "react-scripts": "^5.0.1",
     "reactstrap": "^9.1.5",
     "rimraf": "^6.0.0"


### PR DESCRIPTION
## 📑 Description
Pin react-router-dom to version 7.7.0

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Build:
- Lock react-router-dom to 7.7.0 in package.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version of "react-router-dom" to 7.7.0 to ensure consistent dependency usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->